### PR TITLE
Make ForwardedPort struct public

### DIFF
--- a/Sources/Lib/ForwardedPort.swift
+++ b/Sources/Lib/ForwardedPort.swift
@@ -1,0 +1,48 @@
+import ArgumentParser
+import Foundation
+
+public struct ForwardedPort: Codable {
+	public var proto: MappedPort.Proto = .tcp
+	public var host: Int = -1
+	public var guest: Int = -1
+
+	public init() {
+		
+	}
+}
+
+extension ForwardedPort: CustomStringConvertible, ExpressibleByArgument {
+	public var description: String {
+		"\(host):\(guest)/\(proto)"
+	}
+
+	public init(argument: String) {
+		self.init()
+
+		let expr = try! NSRegularExpression(pattern: #"(?<host>\d+)(:(?<guest>\d+)(\/(?<proto>tcp|udp|both))?)?"#, options: [])
+		let range = NSRange(argument.startIndex..<argument.endIndex, in: argument)
+
+		guard let match = expr.firstMatch(in: argument, options: [], range: range) else {
+			return
+		}
+
+		if let hostRange = Range(match.range(withName: "host"), in: argument) {
+			self.host = Int(argument[hostRange]) ?? 0
+		}
+
+		if let guestRange = Range(match.range(withName: "guest"), in: argument) {
+			self.guest = Int(argument[guestRange]) ?? 0
+		} else {
+			self.guest = self.host
+		}
+
+		self.proto = .tcp
+
+		if let protoRange = Range(match.range(withName: "proto"), in: argument) {
+			if let proto = MappedPort.Proto(rawValue: String(argument[protoRange])) {
+				self.proto = proto
+			}
+		}
+	}
+}
+

--- a/Sources/Main/Root.swift
+++ b/Sources/Main/Root.swift
@@ -5,51 +5,6 @@ import NIOPortForwarding
 
 let COMMAND_NAME="nio-pfw"
 
-public struct ForwardedPort: Codable {
-	public var proto: MappedPort.Proto = .tcp
-	public var host: Int = -1
-	public var guest: Int = -1
-
-	public init() {
-		
-	}
-}
-
-extension ForwardedPort: CustomStringConvertible, ExpressibleByArgument {
-	public var description: String {
-		"\(host):\(guest)/\(proto)"
-	}
-
-	public init(argument: String) {
-		self.init()
-
-		let expr = try! NSRegularExpression(pattern: #"(?<host>\d+)(:(?<guest>\d+)(\/(?<proto>tcp|udp|both))?)?"#, options: [])
-		let range = NSRange(argument.startIndex..<argument.endIndex, in: argument)
-
-		guard let match = expr.firstMatch(in: argument, options: [], range: range) else {
-			return
-		}
-
-		if let hostRange = Range(match.range(withName: "host"), in: argument) {
-			self.host = Int(argument[hostRange]) ?? 0
-		}
-
-		if let guestRange = Range(match.range(withName: "guest"), in: argument) {
-			self.guest = Int(argument[guestRange]) ?? 0
-		} else {
-			self.guest = self.host
-		}
-
-		self.proto = .tcp
-
-		if let protoRange = Range(match.range(withName: "proto"), in: argument) {
-			if let proto = MappedPort.Proto(rawValue: String(argument[protoRange])) {
-				self.proto = proto
-			}
-		}
-	}
-}
-
 @main
 struct Root: ParsableCommand {
 	static var configuration = CommandConfiguration(

--- a/Sources/Main/Root.swift
+++ b/Sources/Main/Root.swift
@@ -60,7 +60,7 @@ struct Root: ParsableCommand {
 	@Argument(help: "Remote host forwarded port")
 	public var remoteHost: String = "localhost"
 
-	@Option(name: [.customLong("forward"), .customShort("f")], help: ArgumentHelp("forwarded port for host", valueName: "host:guest/(tcp|udp|both)"))
+	@Option(name: [.customLong("forward"), .customShort("f")], help: ArgumentHelp("Forwarded port for host", valueName: "host port:guest port/(tcp|udp|both)"))
 	public var forwardedPorts: [ForwardedPort] = []
 
 	@Option(name: [.customLong("ttl"), .customShort("t")], help: "TTL for UDP relay connection in seconds")

--- a/Tests/PortForwarderTests/ForwardedPortTest.swift
+++ b/Tests/PortForwarderTests/ForwardedPortTest.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+@testable import NIOPortForwarding
+
+final class ForwardedPortTests: XCTestCase {
+
+	func testHostPortOnly() throws {
+		let forwardedPort = ForwardedPort(argument: "80")
+
+		XCTAssertEqual(forwardedPort.description, "80:80/tcp")
+	}
+
+	func testHostAndGuestPortOnly() throws {
+		let forwardedPort = ForwardedPort(argument: "80:8080")
+
+		XCTAssertEqual(forwardedPort.description, "80:8080/tcp")
+	}
+
+	func testHostAndGuestPortWithProtocol() throws {
+		let forwardedPort = ForwardedPort(argument: "80:8080/both")
+
+		XCTAssertEqual(forwardedPort.description, "80:8080/both")
+	}
+}


### PR DESCRIPTION
ForwardedPort is not public

### Motivation:

The struct ForwardedPort is declared in the wrong file and it's not public

### Modifications:

Move the ForwardedPort struct to library and make it public

### Result:

ForwardedPort exposed to public
