### PR TITLE
Multiple addresses binding

### DIFF
--- a/Sources/Lib/Forwarder.swift
+++ b/Sources/Lib/Forwarder.swift
@@ -70,7 +70,7 @@ public class PortForwarder {
 		try? self.group.syncShutdownGracefully()
 	}
 
-	public init(group: EventLoopGroup, remoteHost: String, mappedPorts: [MappedPort], bindAddress: String = "127.0.0.1", udpConnectionTTL: Int = 5) throws {
+	public init(group: EventLoopGroup, remoteHost: String, mappedPorts: [MappedPort], bindAddresses: [String] = ["127.0.0.1", "::1"], udpConnectionTTL: Int = 5) {
 		self.remoteHost = remoteHost
 		self.mappedPorts = mappedPorts
 		self.bindAddress = bindAddress
@@ -95,10 +95,10 @@ public class PortForwarder {
 		}
 	}
 
-	public convenience init(remoteHost: String, mappedPorts: [MappedPort], bindAddress: String = "127.0.0.1", udpConnectionTTL: Int = 5) throws {
+	public convenience init(group: EventLoopGroup, remoteHost: String, mappedPorts: [MappedPort], bindAddress: String = "127.0.0.1", udpConnectionTTL: Int = 5) {
 		let group = MultiThreadedEventLoopGroup(numberOfThreads: mappedPorts.count)
 
-		try self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: bindAddress, udpConnectionTTL: udpConnectionTTL)
+		self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: bindAddress, udpConnectionTTL: udpConnectionTTL)
 	}
 
 	public func syncShutdownGracefully() throws {

--- a/Sources/Lib/Forwarder.swift
+++ b/Sources/Lib/Forwarder.swift
@@ -53,7 +53,7 @@ public struct PortForwarderClosure {
 
 public class PortForwarder {
 	let group: EventLoopGroup
-	let bindAddress: String
+	let bindAddresses: [String]
 	let mappedPorts: [MappedPort]
 	let remoteHost: String
 	let serverBootstrap: [PortForwarding]
@@ -73,32 +73,43 @@ public class PortForwarder {
 	public init(group: EventLoopGroup, remoteHost: String, mappedPorts: [MappedPort], bindAddresses: [String] = ["127.0.0.1", "::1"], udpConnectionTTL: Int = 5) {
 		self.remoteHost = remoteHost
 		self.mappedPorts = mappedPorts
-		self.bindAddress = bindAddress
-		self.group = group
-		
-		self.serverBootstrap = mappedPorts.reduce([]) { serverBootstrap, mappedPort in
-			var serverBootstrap = serverBootstrap
-			let bindAddress = try! SocketAddress.makeAddressResolvingHost(bindAddress, port: mappedPort.host)
-			let remoteAddress = try! SocketAddress.makeAddressResolvingHost(remoteHost, port: mappedPort.guest)
+		self.bindAddresses = bindAddresses
+		self.group = group		
+		self.serverBootstrap = bindAddresses.reduce([]) { serverBootstrap, bindAddress in
+			return mappedPorts.reduce(serverBootstrap) { serverBootstrap, mappedPort in
+				var serverBootstrap = serverBootstrap
+				let bindAddress = try! SocketAddress.makeAddressResolvingHost(bindAddress, port: mappedPort.host)
+				let remoteAddress = try! SocketAddress.makeAddressResolvingHost(remoteHost, port: mappedPort.guest)
 
-			switch mappedPort.proto {
-				case .tcp:
-					serverBootstrap.append(TCPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress))
-				case .both:
-					serverBootstrap.append(TCPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress))
-					serverBootstrap.append(UDPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress, ttl: udpConnectionTTL))
-				default:
-					serverBootstrap.append(UDPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress, ttl: udpConnectionTTL))
+				switch mappedPort.proto {
+					case .tcp:
+						serverBootstrap.append(TCPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress))
+					case .both:
+						serverBootstrap.append(TCPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress))
+						serverBootstrap.append(UDPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress, ttl: udpConnectionTTL))
+					default:
+						serverBootstrap.append(UDPPortForwardingServer(group: group, bindAddress: bindAddress, remoteAddress: remoteAddress, ttl: udpConnectionTTL))
+				}
+
+				return serverBootstrap
 			}
-
-			return serverBootstrap
 		}
 	}
 
 	public convenience init(group: EventLoopGroup, remoteHost: String, mappedPorts: [MappedPort], bindAddress: String = "127.0.0.1", udpConnectionTTL: Int = 5) {
+		self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddresses: [bindAddress], udpConnectionTTL: udpConnectionTTL)
+	}
+
+	public convenience init(remoteHost: String, mappedPorts: [MappedPort], bindAddresses: [String] = ["127.0.0.1", "::1"], udpConnectionTTL: Int = 5) {
 		let group = MultiThreadedEventLoopGroup(numberOfThreads: mappedPorts.count)
 
-		self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: bindAddress, udpConnectionTTL: udpConnectionTTL)
+		self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddresses: bindAddresses, udpConnectionTTL: udpConnectionTTL)
+	}
+
+	public convenience init(remoteHost: String, mappedPorts: [MappedPort], bindAddress: String = "127.0.0.1", udpConnectionTTL: Int = 5) {
+		let group = MultiThreadedEventLoopGroup(numberOfThreads: mappedPorts.count)
+
+		self.init(group: group, remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddresses: [bindAddress], udpConnectionTTL: udpConnectionTTL)
 	}
 
 	public func syncShutdownGracefully() throws {

--- a/Sources/Main/Root.swift
+++ b/Sources/Main/Root.swift
@@ -39,7 +39,7 @@ struct Root: ParsableCommand {
 	}
 
 	mutating func run() throws {
-		let pfw = try PortForwarder(remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: "0.0.0.0", udpConnectionTTL: udpTTL)
+		let pfw = PortForwarder(remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: "0.0.0.0", udpConnectionTTL: udpTTL)
 
 		try pfw.bind().wait()
 	}

--- a/Tests/PortForwarderTests/TCPForwardingTest.swift
+++ b/Tests/PortForwarderTests/TCPForwardingTest.swift
@@ -197,10 +197,10 @@ final class TCPForwardingTests: XCTestCase {
 		return server
 	}
 
-	func setupForwarder(host: String, port: Int, guest: Int) throws -> PortForwarder {
+	func setupForwarder(host: String, port: Int, guest: Int) -> PortForwarder {
 		Log(label: "TCPForwardingTests").info("Setup forwarder: \(host), port: \(port), guest: \(guest)")
 
-		let portForwarder = try PortForwarder(group: self.group.next(),
+		let portForwarder = PortForwarder(group: self.group.next(),
 						remoteHost: host,
 						mappedPorts: [MappedPort(host: port, guest: guest, proto: .tcp)],
 						bindAddress: host)
@@ -222,7 +222,7 @@ final class TCPForwardingTests: XCTestCase {
 	}
 
 	func testTCPEchoForwarding() async throws {
-		let forwarder = try assertNoThrowWithValue(self.setupForwarder(host: defaultEchoHost, port: defaultForwardPort, guest: defaultServerPort))
+		let forwarder = self.setupForwarder(host: defaultEchoHost, port: defaultForwardPort, guest: defaultServerPort)
 
 		_ = try assertNoThrowWithValue(forwarder.bind())
 

--- a/Tests/PortForwarderTests/UDPForwardingTest.swift
+++ b/Tests/PortForwarderTests/UDPForwardingTest.swift
@@ -166,7 +166,7 @@ final class UDPForwardingTests: XCTestCase {
 	func setupForwarder(host: String, port: Int, guest: Int) -> PortForwarder {
 		self.logger.info("Setup forwarder: \(host), port: \(port), guest: \(guest)")
 
-		let portForwarder = try! PortForwarder(group: self.group.next(),
+		let portForwarder = PortForwarder(group: self.group.next(),
 						remoteHost: host,
 						mappedPorts: [MappedPort(host: port, guest: guest, proto: .udp)],
 						bindAddress: host)


### PR DESCRIPTION
Allows to bind multiple addresses for port forwarding

### Motivation:

Initial release permit only to bind a single address so it was possible to bind only a specific address or all.

Also constructors declare throws but never throw error. So need to remove it.

### Modifications:

Add constructor with array of addresses to bind and remove throws declaration on all constructors.

### Result:

A new constructor
