### PR TITLE
Allow to close forwarder and bind again later

### DIFF
--- a/Sources/Lib/PortForwarding.swift
+++ b/Sources/Lib/PortForwarding.swift
@@ -20,7 +20,7 @@ public protocol PortForwarding: Equatable {
 	var channel: Channel? { get }
 	var eventLoop: EventLoop { get }
 
-	func setChannel(_ channel: Channel)
+	func setChannel(_ channel: Channel?)
 	func bind() -> EventLoopFuture<Channel>
 	func close() -> EventLoopFuture<Void>
 }
@@ -55,6 +55,8 @@ extension PortForwarding {
 			// The server wasn't created yet, so we can just shut down straight away and let the OS clean us up.
 			return self.eventLoop.makeSucceededVoidFuture()
 		}
+
+		self.setChannel(nil)
 
 		Log(self).debug("Close on \(String(describing: channel.localAddress))")
 

--- a/Sources/Lib/TCPPortForwardingServer.swift
+++ b/Sources/Lib/TCPPortForwardingServer.swift
@@ -77,7 +77,7 @@ open class TCPPortForwardingServer: PortForwarding {
 			}
 	}
 
-	public func setChannel(_ channel: any NIOCore.Channel) {
+	public func setChannel(_ channel: Channel?) {
 		self.channel = channel
 	}
 }

--- a/Sources/Lib/UDPPortForwardingServer.swift
+++ b/Sources/Lib/UDPPortForwardingServer.swift
@@ -197,7 +197,7 @@ open class UDPPortForwardingServer: PortForwarding {
 		channel.pipeline.addHandler(InboundUDPWrapperHandler(remoteAddress: remoteAddress, bindAddress: bindAddress, ttl: ttl))
     }
 
-	public func setChannel(_ channel: any NIOCore.Channel) {
+	public func setChannel(_ channel: Channel?) {
 		self.channel = channel
 	}
 }

--- a/Sources/Main/Root.swift
+++ b/Sources/Main/Root.swift
@@ -39,7 +39,7 @@ struct Root: ParsableCommand {
 	}
 
 	mutating func run() throws {
-		let pfw = try PortForwarder(remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddress: "0.0.0.0", udpConnectionTTL: udpTTL)
+		let pfw = try PortForwarder(remoteHost: remoteHost, mappedPorts: mappedPorts, bindAddresses: ["0.0.0.0", "[::]"], udpConnectionTTL: udpTTL)
 
 		try pfw.bind().wait()
 	}


### PR DESCRIPTION
This PR allows the forwarder to temporary closed without shutdown and rebind later.