### PR TITLE
Ensures port forwarding closes before removal

### DIFF
--- a/Sources/Lib/Forwarder.swift
+++ b/Sources/Lib/Forwarder.swift
@@ -384,8 +384,9 @@ open class PortForwarder: @unchecked Sendable {
 			throw PortForwardingError.notFound("Port forwarding not found for \(proto):\(bindAddress) -> \(remoteAddress)")
 		}
 
-		// Remove the port forwarding from the list
-		self.serverBootstrap.removeAll(where: filter)
+		EventLoopFuture.andAllComplete(concerned.map { $0.close() }, on: self.group.next()).whenComplete { result in
+			self.serverBootstrap.removeAll(where: filter)
+		}
 	}
 
 	public func addPortForwardingServer(remoteHost: String, mappedPorts: [MappedPort], bindAddress: String, udpConnectionTTL: Int = 5) throws -> [any PortForwarding] {

--- a/Sources/Lib/PortForwarding.swift
+++ b/Sources/Lib/PortForwarding.swift
@@ -26,10 +26,14 @@ public protocol PortForwarding: Equatable {
 }
 
 extension PortForwarding {
+	public func equals(_ other: any PortForwarding) -> Bool {
+		return self.bindAddress == other.bindAddress
+			&& self.remoteAddress == other.remoteAddress
+			&& self.proto == other.proto
+	}
+
 	public static func == (lhs: Self, rhs: Self) -> Bool {
-		return lhs.bindAddress == rhs.bindAddress
-			&& lhs.remoteAddress == rhs.remoteAddress
-			&& lhs.proto == rhs.proto
+		lhs.equals(rhs)
 	}
 }
 


### PR DESCRIPTION
Ensures that a port forwarding instance is properly closed before it is removed from the list of active forwarders. This prevents potential resource leaks or unexpected behavior.

- Closes the port forwarding instance asynchronously using `EventLoopFuture.andAllComplete` to ensure all close operations are completed.
- Modifies the `PortForwarding` protocol extension to use a dedicated `equals` function to avoid implicit self capture.