### PR TITLE
Moves ArgumentParser dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
 		.target(
 			name: "NIOPortForwarding",
 			dependencies: [
-				.product(name: "ArgumentParser", package: "swift-argument-parser"),
 				.product(name: "NIOCore", package: "swift-nio"),
 				.product(name: "NIOPosix", package: "swift-nio"),
 				.product(name: "NIOHTTP1", package: "swift-nio"),
@@ -35,6 +34,7 @@ let package = Package(
 			name: "PortForwarder",
 			dependencies: [
 				.target(name: "NIOPortForwarding"),
+				.product(name: "ArgumentParser", package: "swift-argument-parser"),
 				.product(name: "NIOCore", package: "swift-nio"),
 				.product(name: "NIOPosix", package: "swift-nio"),
 				.product(name: "NIOHTTP1", package: "swift-nio"),


### PR DESCRIPTION
Moves the `ArgumentParser` dependency from `NIOPortForwarding` to `PortForwarder`.

### Motivation:

The `ArgumentParser` library is primarily used by executable targets for command-line argument parsing. The `PortForwarder` target is the executable component that directly utilizes this functionality, whereas `NIOPortForwarding` is a library target providing core logic. This adjustment ensures that dependencies are declared only where they are strictly needed, leading to a cleaner and more logical dependency graph.

### Modifications:

The `swift-argument-parser` product dependency has been removed from the `NIOPortForwarding` target and subsequently added to the `PortForwarder` target within `Package.swift`.

### Result:

The `PortForwarder` executable correctly declares its dependency on `ArgumentParser`. The `NIOPortForwarding` library no longer carries an unnecessary dependency, which improves modularity and potentially build times for consumers of `NIOPortForwarding` that do not require argument parsing.